### PR TITLE
Updated Travis CI link.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ Libaudioverse
 
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/wmoa6isbe8fdmg2c?svg=true)](https://ci.appveyor.com/project/camlorn/libaudioverse)
 
-[![Linux Build Status](https://travis-ci.org/libaudioverse/libaudioverse.svg?branch=master)](https://travis-ci.org/camlorn/libaudioverse)
+[![Linux Build Status](https://travis-ci.org/libaudioverse/libaudioverse.svg?branch=master)](https://travis-ci.org/libaudioverse/libaudioverse)
 
 [GitHub](http://github.com/libaudioverse/libaudioverse)
 


### PR DESCRIPTION
The link has somehow not been changed since the repository was moved to the libaudioverse organization.

This is PR'd to master because it's for the readme, which isn't going to break anything, and should be accurate.  I'm not sure if you would still prefer minor non-code commits to be made to the development branch.